### PR TITLE
Update Slackbot.swift

### DIFF
--- a/SwiftSlackbots/Slackbot.swift
+++ b/SwiftSlackbots/Slackbot.swift
@@ -86,7 +86,7 @@ class Slackbot {
         
         if icon != nil {
             if let emojiRange = icon!.range(of: ":[a-z_0-9-+]+:", options: .regularExpression) {
-                slackJsonElements["icon_emoji"] = icon!.substring(with: emojiRange)
+                slackJsonElements["icon_emoji"] = icon!.self[emojiRange]
             } else {
                 slackJsonElements["icon_url"] = icon
             }


### PR DESCRIPTION
Fixed for Swift 5 to remove 'substring(with:)' is deprecated: Please use String slicing subscript. 
Changed icon!.substring(with: emojiRange)  to  icon!.self[emojiRange]